### PR TITLE
categories and tags bug fix, need to update ACF in WPADMIN as well

### DIFF
--- a/archive-studentresource.php
+++ b/archive-studentresource.php
@@ -9,17 +9,18 @@ do_action( 'after_archive_header' ); ?>
     <?php
         $key = 'tag';
         $field = acf_get_field($key);
+        
       
     if ($field) {
-       foreach ($field['choices'] as $key => $value) {
+       foreach ($field['choices'] as $value => $label) {
         $taggedPosts = new WP_Query(array(
             'post_type' => 'studentresource',
             'posts_per_page' => 10,
-            'meta_value'=> $value
+            'meta_value' => $value           
          ));
         ?>
         <div class="filters-container" class="expand-btn" data-toggle="collapse" data-target="#resource-items-<?php echo($value)?>">
-        <h2> <?php echo ($value);  ?>  </h2>
+            <h2> <?php echo ($label);  ?>  </h2>
             <button class="expand-btn" data-toggle="collapse" data-target="#resource-items-<?php echo($value)?>">  <i class="fas fa-chevron-down fa-2x"></i> </button>  
         </div>    
                 

--- a/archive-teachingresource.php
+++ b/archive-teachingresource.php
@@ -11,15 +11,16 @@ do_action( 'after_archive_header' ); ?>
         $field = acf_get_field($key);
       
     if ($field) {
-       foreach ($field['choices'] as $key => $value) {
+       foreach ($field['choices'] as $value => $label) {
         $taggedPosts = new WP_Query(array(
             'post_type' => 'teachingresource',
             'posts_per_page' => 10,
             'meta_value'=> $value
          ));
         ?>
+        <!-- This is responsible for creating the div with a header and a dropdown chevron-->
         <div class="filters-container" class="expand-btn" data-toggle="collapse" data-target="#resource-items-<?php echo($value)?>">
-           <h2> <?php echo ($value);  ?>  </h2>
+           <h2> <?php echo ($label);  ?>  </h2>
            <button class="expand-btn" data-toggle="collapse" data-target="#resource-items-<?php echo($value)?>">  <i class="fas fa-chevron-down fa-2x"></i> </button>  
         </div>    
                 

--- a/single-teachingresource.php
+++ b/single-teachingresource.php
@@ -22,13 +22,11 @@ do_action( 'after_archive_header' ); ?>
 				
 				<h4>Tag(s)</h4>
                 <ul class="no-bullets">
-                <?php if( get_field('tag') ): ?>
-						<li><?php the_field('tag'); ?></li>
+                <?php if( get_field('category') ): ?>
+						<li><?php the_field('category'); ?></li>
 					<?php endif ?>
                 </ul>
-				<!--<h4>Site Preview</h4>
-				<iframe width="700" height="400" src="<?php the_field('resource_link');?>"></iframe>
-				<br>-->			
+						
 			</div>
 			<nav class="further-reading">
 				<div class="previous">


### PR DESCRIPTION
There was a bad bug with "categories/tags" that were more than one word. It is fixed in the code. I will need to made a few updates in WPAdmin as well once the code is pushed.